### PR TITLE
Attempt to fix deletion of prexisting text in interactive mode on the…

### DIFF
--- a/gptokeyb.cpp
+++ b/gptokeyb.cpp
@@ -1170,6 +1170,7 @@ bool handleEvent(const SDL_Event& event)
               if (current_character > 0) {
                 current_character--;
               } else if (current_character == 0) {
+                removeTextInputCharacter();
                 initialiseCharacters();
                 addTextInputCharacter();
               }


### PR DESCRIPTION
… RG351P.  This fixes the issue for me where if you press hotkey+left to insert existing text and then try to delete it by pressing hotkey+down to enter interactive text mode then press left I am unable to delete any of the pre-existing text.